### PR TITLE
fix: shell completion scripts parsing of merged --list output

### DIFF
--- a/run/completions/run.bash
+++ b/run/completions/run.bash
@@ -70,7 +70,7 @@ _run_complete() {
         local namespace="$prev"
 
         if command -v run &> /dev/null; then
-            local all_funcs=$(run --list 2>/dev/null | sed -n 's/^  //p')
+            local all_funcs=$(run --list 2>/dev/null | sed 's/ (overrides global)//' | sed -n 's/^  *\([^ ][^ ]*\) *$/\1/p')
             local subcommands=""
 
             while IFS= read -r func; do

--- a/run/completions/run.fish
+++ b/run/completions/run.fish
@@ -17,7 +17,7 @@ function __run_get_top_level
     end
 
     # Get all functions and extract top-level names
-    set -l all_funcs (run --list 2>/dev/null | string match -r '^  \S+' | string trim)
+    set -l all_funcs (run --list 2>/dev/null | string replace ' (overrides global)' '' | string match -r '^\s+\S+$' | string trim)
     set -l top_level
     set -l seen
 
@@ -42,7 +42,7 @@ end
 # Helper function to get subcommands for a namespace
 function __run_get_subcommands
     set -l namespace $argv[1]
-    set -l all_funcs (run --list 2>/dev/null | string match -r '^  \S+' | string trim)
+    set -l all_funcs (run --list 2>/dev/null | string replace ' (overrides global)' '' | string match -r '^\s+\S+$' | string trim)
 
     for func in $all_funcs
         if string match -q "$namespace:*" $func

--- a/run/completions/run.ps1
+++ b/run/completions/run.ps1
@@ -11,7 +11,8 @@
                 $listOutput = & run --list 2>$null
                 if ($LASTEXITCODE -eq 0 -and $listOutput) {
                     $listOutput | ForEach-Object {
-                        if ($_ -match '^\s{2}(\S+)') {
+                        $line = $_ -replace ' \(overrides global\)', ''
+                        if ($line -match '^\s+(\S+)\s*$') {
                             $matches[1]
                         }
                     }

--- a/run/completions/run.zsh
+++ b/run/completions/run.zsh
@@ -18,7 +18,7 @@ _run() {
         local list_output
         list_output=$($run_cmd --list 2>/dev/null)
         if [[ $? -eq 0 && -n "$list_output" ]]; then
-            all_funcs=("${(@f)$(echo $list_output | command sed -n 's/^  //p')}")
+            all_funcs=("${(@f)$(echo $list_output | command sed 's/ (overrides global)//' | command sed -n 's/^  *\([^ ][^ ]*\) *$/\1/p')}")
         fi
     fi
 


### PR DESCRIPTION
The --list output format changed when local/global runfile merging was
added. Multi-source output uses 4-space indentation and includes header
lines like "From ./Runfile:" and "(overrides global)" annotations. The
completion scripts were only handling the old 2-space single-source
format, causing them to inject extra spaces and show "From Runfile" and
"From ~/.runfile" as completion candidates.

Fix all four shells (bash, zsh, fish, powershell) to:
- Strip " (overrides global)" annotations before parsing
- Match only lines containing a single word after whitespace (excludes
  header lines like "From ./Runfile:" which contain spaces)
- Handle both 2-space and 4-space indentation

https://claude.ai/code/session_01Cfd7NFDdWmATKwmPbGQA4B